### PR TITLE
Fix test testWriteReadImage.

### DIFF
--- a/src/test/java/org/dcache/rados4j/RbdTest.java
+++ b/src/test/java/org/dcache/rados4j/RbdTest.java
@@ -130,9 +130,10 @@ public class RbdTest {
                 ByteBuffer b = ByteBuffer.allocateDirect(bufSize / 2);
                 b.limit(b.capacity());
                 image.read(b, i * bufSize / 2);
+                // Reset the position to compute the right digest. 
+                b.flip();
                 mdOut.update(b);
             }
-
             assertArrayEquals(mdIn.digest(), mdOut.digest());
         }
 


### PR DESCRIPTION
Fix test testWriteReadImage. 
With digest update using ByteBuffer, the digest is updated using the input.remaining() bytes starting at input.position() but after calling `RbdImage.read` the position is updated.