### PR TITLE
rados4j: Data corruption on write.

### DIFF
--- a/src/main/java/org/dcache/rados4j/RbdImage.java
+++ b/src/main/java/org/dcache/rados4j/RbdImage.java
@@ -34,10 +34,10 @@ public class RbdImage implements AutoCloseable {
     }
 
     public int write(ByteBuffer buf, long offset) throws RadosException {
-        int rc = rbd.rbd_write(image, offset, buf.remaining(), buf);
+        int rc = rbd.rbd_write(image, offset, buf.remaining(), buf.slice());
         checkError(runtime, rc, "Failed to write into image " + name);
         // JNI interface does not updates the position
-        buf.position( buf.position() + rc);
+        buf.position(buf.position() + rc);
         return rc;
     }
 


### PR DESCRIPTION
Motivation:

For write operation and an input ByteBuffer with a different current position
than the beginning (as dCache can provide), the native `rbd.rbd_write` can write
corrupted data in the destination image.

Modification:

- Change the content of the Bytebuffer to start at its current position and finish at the limit.
- Add testcase to valide writing with Bytebuffer's current position different than 0.

Result:

No data corruption when writing to Ceph.

Target: master
Require-notes: yes
Require-book: yes
Request: 5